### PR TITLE
Upgrade to hhvm 4.34

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 vendor
 www.pid
+**/*hhast.parser-cache

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,5 @@
         "psr-4": {
 	        "Usox\\Sharesta\\": "src"
         }
-    },
-    "config": {
-        "platform": {
-            "hhvm": "4.1.0"
-        }
     }
 }

--- a/src/RequestBody.hh
+++ b/src/RequestBody.hh
@@ -9,9 +9,11 @@ final class RequestBody implements RequestBodyInterface {
   private ?dict<string, mixed> $getBodyCache;
   private ?IO\ReadHandle $input;
 
-  public function useIO(IO\ReadHandle $input): this{
-    $this->input = $input;
-    $this->getBodyCache = null;
+  public function useIO(?IO\ReadHandle $input): this{
+    if($input !== $this->input){
+      $this->input = $input;
+      $this->getBodyCache = null;
+    }
     return $this;
   }
 

--- a/src/RequestBody.hh
+++ b/src/RequestBody.hh
@@ -2,12 +2,26 @@
 namespace Usox\Sharesta;
 
 use namespace Facebook\TypeAssert;
+use namespace HH\Lib\Experimental\IO;
 
 final class RequestBody implements RequestBodyInterface {
 
-	<<__Memoize>>
+  private ?dict<string, mixed> $getBodyCache;
+  private ?IO\ReadHandle $input;
+
+  public function useIO(IO\ReadHandle $input): this{
+    $this->input = $input;
+    $this->getBodyCache = null;
+    return $this;
+  }
+
 	public function getBody(): dict<string,mixed> {
-		$body = \file_get_contents('php://input');
+    if($this->getBodyCache is nonnull){
+      return $this->getBodyCache;
+    }
+    $req_input = IO\request_input();
+    $body = $this->input?->rawReadBlocking() ?? $req_input->rawReadBlocking();
+
 		if ($body === '') {
 			return dict([]);
 		}
@@ -57,6 +71,7 @@ final class RequestBody implements RequestBodyInterface {
 		if (!\is_array($value)) {
 			throw new Exception\Request\InvalidRequestParamException('Invalid parameter for key '.$key);
 		}
+    /*HH_FIXME[4110] Can I have integer keys?*/
 		return dict($value);
 	}
 }

--- a/src/RequestBodyInterface.hh
+++ b/src/RequestBodyInterface.hh
@@ -1,7 +1,11 @@
 <?hh // strict
 namespace Usox\Sharesta;
 
+use namespace HH\Lib\Experimental\IO;
+
 interface RequestBodyInterface {
+
+  public function useIO(IO\ReadHandle $input): this;
 
 	public function getBody(): dict<string, mixed>;
 

--- a/src/Router.hh
+++ b/src/Router.hh
@@ -93,7 +93,7 @@ final class Router implements RouterInterface {
 			);
 
 			$uri_params = [];
-			if (\preg_match('%^'.$route_pattern.'$%', $request_prepend.$requested_route, &$uri_params)) {
+			if (\preg_match_with_matches('%^'.$route_pattern.'$%', $request_prepend.$requested_route, inout $uri_params)) {
 
 				foreach ($uri_params as $key => $value) {
 					if (!\is_numeric($key)) {

--- a/src/_private/MockIOHandle.hh
+++ b/src/_private/MockIOHandle.hh
@@ -1,0 +1,38 @@
+<?hh // strict
+
+namespace Usox\Sharesta\_Private;
+
+use namespace HH\Lib\Experimental\IO;
+use namespace HH\Lib\Str;
+
+class MockIOHandle implements IO\ReadHandle {
+  public function __construct(private string $contents) {}
+  public function isEndOfFile(): bool {
+    return false;
+  }
+  public function rawReadBlocking(?int $limit = null): string {
+    if ($limit is nonnull) {
+      throw new \InvalidOperationException(
+        'This class is meant to be injected into tests. Do not use!',
+      );
+    }
+    return $this->contents;
+  }
+  public function readAsync(
+    ?int $_limit = null,
+    ?float $_timeout = null,
+  ): Awaitable<string> {
+    throw new \InvalidOperationException(
+      'This class is meant to be injected into tests. Do not use!',
+    );
+  }
+  public function readLineAsync(
+    ?int $max_bytes = null,
+    ?float $timeout_seconds = null,
+  ): Awaitable<string> {
+    throw new \InvalidOperationException(
+      'This class is meant to be injected into tests. Do not use!',
+    );
+  }
+
+}

--- a/src/_private/MockIOHandle.hh
+++ b/src/_private/MockIOHandle.hh
@@ -3,7 +3,6 @@
 namespace Usox\Sharesta\_Private;
 
 use namespace HH\Lib\Experimental\IO;
-use namespace HH\Lib\Str;
 
 class MockIOHandle implements IO\ReadHandle {
   public function __construct(private string $contents) {}
@@ -27,8 +26,8 @@ class MockIOHandle implements IO\ReadHandle {
     );
   }
   public function readLineAsync(
-    ?int $max_bytes = null,
-    ?float $timeout_seconds = null,
+    ?int $_max_bytes = null,
+    ?float $_timeout_seconds = null,
   ): Awaitable<string> {
     throw new \InvalidOperationException(
       'This class is meant to be injected into tests. Do not use!',

--- a/tests/RequestBodyTest.hh
+++ b/tests/RequestBodyTest.hh
@@ -19,7 +19,7 @@ class RequestBodyTest extends \Facebook\HackTest\HackTest {
 
 		expect(
 			function () {
-        $this->with();
+        $this->request_body->getBody();
 			}
 		)
 		->toThrow(
@@ -159,7 +159,7 @@ class RequestBodyTest extends \Facebook\HackTest\HackTest {
 	private function getRequestBody(array<string, mixed>$input): dict<string, mixed> {
 		$this->fillBody($input);
 
-		return $this->with();	
+		return $this->request_body->getBody();	
 	}
 
 	private function fillBody(array<string, mixed> $body): void {
@@ -169,9 +169,5 @@ class RequestBodyTest extends \Facebook\HackTest\HackTest {
   private function fillBodyWithString(string $input): void{
     $this->setUp();
     $this->request_body->useIO(new _Private\MockIOHandle($input));
-  }
-
-  private function with(): dict<string, mixed>{
-    return $this->request_body->getBody();
   }
 }


### PR DESCRIPTION
Changes the API of RequestBody to allow setting a custom ReadHandle
This allows us to test using $request_handle->useIO()
This might actually also prove useful for normal use, but idk